### PR TITLE
重构api设置以及模型选择功能

### DIFF
--- a/app/src/main/java/com/roubao/autopilot/MainActivity.kt
+++ b/app/src/main/java/com/roubao/autopilot/MainActivity.kt
@@ -260,15 +260,26 @@ class MainActivity : ComponentActivity() {
                             )
                             Screen.Settings -> SettingsScreen(
                                 settings = settings,
-                                onUpdateApiKey = { settingsManager.updateApiKey(it) },
-                                onUpdateBaseUrl = { settingsManager.updateBaseUrl(it) },
-                                onUpdateModel = { settingsManager.updateModel(it) },
-                                onAddCustomModel = { settingsManager.addCustomModel(it) },
-                                onRemoveCustomModel = { settingsManager.removeCustomModel(it) },
+                                onAddProvider = { name, url, key -> settingsManager.addProvider(name, url, key) },
+                                onUpdateProvider = { id, name, url, key -> settingsManager.updateProvider(id, name, url, key) },
+                                onRemoveProvider = { id -> settingsManager.removeProvider(id) },
+                                onSelectProvider = { id -> settingsManager.setActiveProvider(id) },
+                                onAddModelsToProvider = { providerId, models -> settingsManager.addModelsToProvider(providerId, models) },
+                                onRemoveModelFromProvider = { providerId, model -> settingsManager.removeModelFromProvider(providerId, model) },
+                                onSelectModel = { model -> settingsManager.updateModel(model) },
                                 onUpdateThemeMode = { settingsManager.updateThemeMode(it) },
                                 onUpdateMaxSteps = { settingsManager.updateMaxSteps(it) },
-                                allModels = settingsManager.getAllModels(),
-                                shizukuAvailable = isShizukuAvailable
+                                shizukuAvailable = isShizukuAvailable,
+                                onFetchModels = { url, key, onSuccess, onError ->
+                                    lifecycleScope.launch {
+                                        val result = VLMClient.fetchModels(url, key)
+                                        result.onSuccess { models ->
+                                            onSuccess(models)
+                                        }.onFailure { error ->
+                                            onError(error.message ?: "Unknown error")
+                                        }
+                                    }
+                                }
                             )
                         }
                     }

--- a/app/src/main/java/com/roubao/autopilot/data/SettingsManager.kt
+++ b/app/src/main/java/com/roubao/autopilot/data/SettingsManager.kt
@@ -5,39 +5,34 @@ import android.content.SharedPreferences
 import com.roubao.autopilot.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
 
 /**
  * API 提供商配置
  */
-data class ApiProvider(
+data class ProviderConfig(
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
     val baseUrl: String,
-    val defaultModel: String
-) {
-    companion object {
-        val ALIYUN = ApiProvider(
-            name = "阿里云 (Qwen-VL)",
-            baseUrl = "https://dashscope.aliyuncs.com/compatible-mode/v1",
-            defaultModel = "qwen3-vl-plus"
-        )
-        val MODELSCOPE = ApiProvider(
-            name = "ModelScope",
-            baseUrl = "https://api-inference.modelscope.cn/v1",
-            defaultModel = "iic/GUI-Owl-7B"
-        )
-
-        val ALL = listOf(ALIYUN, MODELSCOPE)
-    }
-}
+    val apiKey: String,
+    val models: List<String> = emptyList()
+)
 
 /**
  * 应用设置
  */
 data class AppSettings(
+    // 兼容旧字段，实际上由 activeProvider 决定
     val apiKey: String = "",
-    val baseUrl: String = ApiProvider.ALIYUN.baseUrl,
-    val model: String = ApiProvider.ALIYUN.defaultModel,
-    val customModels: List<String> = emptyList(),
+    val baseUrl: String = "",
+    val model: String = "",
+    
+    // 新增字段
+    val providers: List<ProviderConfig> = emptyList(),
+    val activeProviderId: String = "",
+    
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val hasSeenOnboarding: Boolean = false,
     val maxSteps: Int = 25
@@ -54,6 +49,28 @@ class SettingsManager(context: Context) {
     private val _settings = MutableStateFlow(loadSettings())
     val settings: StateFlow<AppSettings> = _settings
 
+    companion object {
+        private const val KEY_PROVIDERS = "providers_json"
+        private const val KEY_ACTIVE_PROVIDER_ID = "active_provider_id"
+        
+        val DEFAULT_PROVIDERS = listOf(
+            ProviderConfig(
+                id = "aliyun",
+                name = "阿里云 (Qwen-VL)",
+                baseUrl = "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                apiKey = "",
+                models = listOf("qwen3-vl-plus", "qwen-vl-max", "qwen-vl-plus")
+            ),
+            ProviderConfig(
+                id = "modelscope",
+                name = "ModelScope",
+                baseUrl = "https://api-inference.modelscope.cn/v1",
+                apiKey = "",
+                models = listOf("iic/GUI-Owl-7B")
+            )
+        )
+    }
+
     private fun loadSettings(): AppSettings {
         val themeModeStr = prefs.getString("theme_mode", ThemeMode.DARK.name) ?: ThemeMode.DARK.name
         val themeMode = try {
@@ -61,61 +78,190 @@ class SettingsManager(context: Context) {
         } catch (e: Exception) {
             ThemeMode.DARK
         }
+
+        // 加载 Providers
+        val providersJson = prefs.getString(KEY_PROVIDERS, null)
+        val providers = if (providersJson != null) {
+            deserializeProviders(providersJson)
+        } else {
+            DEFAULT_PROVIDERS
+        }
+
+        // 加载 Active Provider ID
+        var activeProviderId = prefs.getString(KEY_ACTIVE_PROVIDER_ID, "") ?: ""
+        if (activeProviderId.isEmpty() || providers.none { it.id == activeProviderId }) {
+            activeProviderId = providers.firstOrNull()?.id ?: ""
+        }
+
+        // 获取当前 active provider 的配置
+        val activeProvider = providers.find { it.id == activeProviderId }
+        
+        // 加载当前选中的 model (存储在 prefs 中，key 为 "current_model_{providerId}")
+        val currentModel = if (activeProvider != null) {
+            prefs.getString("current_model_${activeProvider.id}", activeProvider.models.firstOrNull() ?: "") ?: ""
+        } else {
+            ""
+        }
+
         return AppSettings(
-            apiKey = prefs.getString("api_key", AppSettings().apiKey) ?: AppSettings().apiKey,
-            baseUrl = prefs.getString("base_url", AppSettings().baseUrl) ?: AppSettings().baseUrl,
-            model = prefs.getString("model", AppSettings().model) ?: AppSettings().model,
-            customModels = prefs.getStringSet("custom_models", emptySet())?.toList() ?: emptyList(),
+            apiKey = activeProvider?.apiKey ?: "",
+            baseUrl = activeProvider?.baseUrl ?: "",
+            model = currentModel,
+            providers = providers,
+            activeProviderId = activeProviderId,
             themeMode = themeMode,
             hasSeenOnboarding = prefs.getBoolean("has_seen_onboarding", false),
             maxSteps = prefs.getInt("max_steps", 25)
         )
     }
 
-    fun updateApiKey(apiKey: String) {
-        prefs.edit().putString("api_key", apiKey).apply()
-        _settings.value = _settings.value.copy(apiKey = apiKey)
+    private fun saveProviders(providers: List<ProviderConfig>) {
+        val json = serializeProviders(providers)
+        prefs.edit().putString(KEY_PROVIDERS, json).apply()
     }
 
-    fun updateBaseUrl(baseUrl: String) {
-        prefs.edit().putString("base_url", baseUrl).apply()
-        _settings.value = _settings.value.copy(baseUrl = baseUrl)
+    fun addProvider(name: String, baseUrl: String, apiKey: String) {
+        val newProvider = ProviderConfig(
+            name = name,
+            baseUrl = baseUrl,
+            apiKey = apiKey,
+            models = emptyList()
+        )
+        val newProviders = _settings.value.providers + newProvider
+        saveProviders(newProviders)
+        
+        // 如果是第一个，设为默认
+        if (newProviders.size == 1) {
+            setActiveProvider(newProvider.id)
+        } else {
+            _settings.value = _settings.value.copy(providers = newProviders)
+        }
+    }
+
+    fun updateProvider(id: String, name: String, baseUrl: String, apiKey: String) {
+        val currentProviders = _settings.value.providers
+        val index = currentProviders.indexOfFirst { it.id == id }
+        if (index != -1) {
+            val updatedProvider = currentProviders[index].copy(
+                name = name,
+                baseUrl = baseUrl,
+                apiKey = apiKey
+            )
+            val newProviders = currentProviders.toMutableList().apply {
+                set(index, updatedProvider)
+            }
+            saveProviders(newProviders)
+            
+            // 如果更新的是当前 active provider，需要更新 AppSettings 的顶层字段
+            if (id == _settings.value.activeProviderId) {
+                _settings.value = _settings.value.copy(
+                    providers = newProviders,
+                    apiKey = apiKey,
+                    baseUrl = baseUrl
+                )
+            } else {
+                _settings.value = _settings.value.copy(providers = newProviders)
+            }
+        }
+    }
+
+    fun removeProvider(id: String) {
+        val currentProviders = _settings.value.providers
+        val newProviders = currentProviders.filter { it.id != id }
+        saveProviders(newProviders)
+
+        if (id == _settings.value.activeProviderId) {
+            val nextProvider = newProviders.firstOrNull()
+            if (nextProvider != null) {
+                setActiveProvider(nextProvider.id)
+            } else {
+                _settings.value = _settings.value.copy(
+                    providers = newProviders,
+                    activeProviderId = "",
+                    apiKey = "",
+                    baseUrl = "",
+                    model = ""
+                )
+                prefs.edit().remove(KEY_ACTIVE_PROVIDER_ID).apply()
+            }
+        } else {
+            _settings.value = _settings.value.copy(providers = newProviders)
+        }
+    }
+
+    fun setActiveProvider(id: String) {
+        val provider = _settings.value.providers.find { it.id == id } ?: return
+        
+        prefs.edit().putString(KEY_ACTIVE_PROVIDER_ID, id).apply()
+        
+        // 加载该 provider 上次选中的 model
+        val savedModel = prefs.getString("current_model_${id}", provider.models.firstOrNull() ?: "") ?: ""
+        
+        _settings.value = _settings.value.copy(
+            activeProviderId = id,
+            apiKey = provider.apiKey,
+            baseUrl = provider.baseUrl,
+            model = savedModel
+        )
     }
 
     fun updateModel(model: String) {
-        prefs.edit().putString("model", model).apply()
-        _settings.value = _settings.value.copy(model = model)
+        val activeId = _settings.value.activeProviderId
+        if (activeId.isNotEmpty()) {
+            prefs.edit().putString("current_model_$activeId", model).apply()
+            _settings.value = _settings.value.copy(model = model)
+        }
     }
 
-    fun addCustomModel(model: String) {
-        val newModels = (_settings.value.customModels + model).distinct()
-        prefs.edit().putStringSet("custom_models", newModels.toSet()).apply()
-        _settings.value = _settings.value.copy(customModels = newModels)
-    }
+    fun addModelsToProvider(providerId: String, models: List<String>) {
+        val currentProviders = _settings.value.providers
+        val index = currentProviders.indexOfFirst { it.id == providerId }
+        if (index == -1) return
+        
+        val provider = currentProviders[index]
+        val validModels = models.filter { it.isNotBlank() }
+        if (validModels.isEmpty()) return
 
-    fun removeCustomModel(model: String) {
-        val newModels = _settings.value.customModels - model
-        prefs.edit().putStringSet("custom_models", newModels.toSet()).apply()
-        _settings.value = _settings.value.copy(customModels = newModels)
+        val newModels = (provider.models + validModels).distinct()
+        val updatedProvider = provider.copy(models = newModels)
+        
+        val newProviders = currentProviders.toMutableList().apply {
+            set(index, updatedProvider)
+        }
+        saveProviders(newProviders)
+        
+        _settings.value = if (providerId == _settings.value.activeProviderId) {
+            val modelToSelect = if (_settings.value.model.isEmpty()) validModels.first() else _settings.value.model
+            _settings.value.copy(providers = newProviders, model = modelToSelect)
+        } else {
+            _settings.value.copy(providers = newProviders)
+        }
     }
-
-    fun selectProvider(provider: ApiProvider) {
-        updateBaseUrl(provider.baseUrl)
-        updateModel(provider.defaultModel)
-    }
-
-    fun getCurrentProvider(): ApiProvider? {
-        return ApiProvider.ALL.find { it.baseUrl == _settings.value.baseUrl }
-    }
-
-    fun getAllModels(): List<String> {
-        val builtIn = listOf(
-            "qwen3-vl-plus",
-            "qwen-vl-max",
-            "qwen-vl-plus",
-            "iic/GUI-Owl-7B"
-        )
-        return (builtIn + _settings.value.customModels).distinct()
+    
+    fun removeModelFromProvider(providerId: String, model: String) {
+        val currentProviders = _settings.value.providers
+        val index = currentProviders.indexOfFirst { it.id == providerId }
+        if (index == -1) return
+        
+        val provider = currentProviders[index]
+        val newModels = provider.models - model
+        val updatedProvider = provider.copy(models = newModels)
+        
+        val newProviders = currentProviders.toMutableList().apply {
+            set(index, updatedProvider)
+        }
+        saveProviders(newProviders)
+        
+        _settings.value = if (providerId == _settings.value.activeProviderId) {
+            val nextModel = if (_settings.value.model == model) {
+                newModels.firstOrNull() ?: ""
+            } else {
+                _settings.value.model
+            }
+            _settings.value.copy(providers = newProviders, model = nextModel)
+        } else {
+            _settings.value.copy(providers = newProviders)
+        }
     }
 
     fun updateThemeMode(themeMode: ThemeMode) {
@@ -129,8 +275,55 @@ class SettingsManager(context: Context) {
     }
 
     fun updateMaxSteps(maxSteps: Int) {
-        val validSteps = maxSteps.coerceIn(5, 100) // 限制范围 5-100
+        val validSteps = maxSteps.coerceIn(5, 100)
         prefs.edit().putInt("max_steps", validSteps).apply()
         _settings.value = _settings.value.copy(maxSteps = validSteps)
+    }
+
+    // JSON Serialization Helpers
+    private fun serializeProviders(providers: List<ProviderConfig>): String {
+        val jsonArray = JSONArray()
+        providers.forEach { provider ->
+            val jsonObject = JSONObject()
+            jsonObject.put("id", provider.id)
+            jsonObject.put("name", provider.name)
+            jsonObject.put("baseUrl", provider.baseUrl)
+            jsonObject.put("apiKey", provider.apiKey)
+            
+            val modelsArray = JSONArray()
+            provider.models.forEach { modelsArray.put(it) }
+            jsonObject.put("models", modelsArray)
+            
+            jsonArray.put(jsonObject)
+        }
+        return jsonArray.toString()
+    }
+
+    private fun deserializeProviders(json: String): List<ProviderConfig> {
+        val providers = mutableListOf<ProviderConfig>()
+        try {
+            val jsonArray = JSONArray(json)
+            for (i in 0 until jsonArray.length()) {
+                val obj = jsonArray.getJSONObject(i)
+                val modelsList = mutableListOf<String>()
+                val modelsArray = obj.optJSONArray("models")
+                if (modelsArray != null) {
+                    for (j in 0 until modelsArray.length()) {
+                        modelsList.add(modelsArray.getString(j))
+                    }
+                }
+                
+                providers.add(ProviderConfig(
+                    id = obj.getString("id"),
+                    name = obj.getString("name"),
+                    baseUrl = obj.getString("baseUrl"),
+                    apiKey = obj.getString("apiKey"),
+                    models = modelsList
+                ))
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return providers
     }
 }

--- a/app/src/main/java/com/roubao/autopilot/vlm/VLMClient.kt
+++ b/app/src/main/java/com/roubao/autopilot/vlm/VLMClient.kt
@@ -36,6 +36,46 @@ class VLMClient(
     companion object {
         private const val MAX_RETRIES = 3
         private const val RETRY_DELAY_MS = 1000L
+
+        suspend fun fetchModels(baseUrl: String, apiKey: String): Result<List<String>> = withContext(Dispatchers.IO) {
+            try {
+                val client = OkHttpClient.Builder()
+                    .connectTimeout(10, TimeUnit.SECONDS)
+                    .readTimeout(10, TimeUnit.SECONDS)
+                    .build()
+
+                val cleanBaseUrl = baseUrl.removeSuffix("/chat/completions").removeSuffix("/")
+                
+                val request = Request.Builder()
+                    .url("$cleanBaseUrl/models")
+                    .addHeader("Authorization", "Bearer $apiKey")
+                    .get()
+                    .build()
+
+                val response = client.newCall(request).execute()
+                val responseBody = response.body?.string() ?: ""
+
+                if (response.isSuccessful) {
+                    val json = JSONObject(responseBody)
+                    val data = json.optJSONArray("data") ?: JSONArray()
+                    val models = mutableListOf<String>()
+                    for (i in 0 until data.length()) {
+                        val item = data.optJSONObject(i)
+                        if (item != null) {
+                            val id = item.optString("id", "").trim()
+                            if (id.isNotEmpty()) {
+                                models.add(id)
+                            }
+                        }
+                    }
+                    Result.success(models)
+                } else {
+                    Result.failure(Exception("HTTP ${response.code}: $responseBody"))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
重构模型选择器，改为provider与model的形式，支持自定义编辑多个api提供方，分开管理不同模型提供方的模型 如图
![6f4ddbe54aa8e8b39e87d56c7d2bddd7](https://github.com/user-attachments/assets/54ff04ab-7434-4bd5-b795-9b0416bc2b62)
![2691bdf2f3171719972bb5353140f6c3](https://github.com/user-attachments/assets/a7abf255-3ac8-4f10-94d7-270988957a25)
![Screenshot_20251211_175224](https://github.com/user-attachments/assets/a68c5cae-dc55-4715-b3f3-c5ec8bc1cff7)
![Screenshot_20251211_175224](https://github.com/user-attachments/assets/639cf2e9-5da5-4b85-9471-fb8ffec1871a)
![6075a9d43ba17984d0bc4fae4bde9907](https://github.com/user-attachments/assets/a52ebf3b-19e3-4327-88aa-647f4fa3571b)
![d2a4dd9723a06e823589846ffc21e195](https://github.com/user-attachments/assets/048fa290-cc8c-4897-86c4-8e15cac72b48)

有几个地方可能需要调整一下